### PR TITLE
release pull request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Change Log
 
 ## [0.0.9]
+- [**Improvement**] history item label will be bold and will now start showing time it executed for better difference
+- [**Improvement**] execute quick pick item, will not start showing urls also.
+- [**Improvement**] Configure response directory name.
 - [**Bug**] don't set default python3 path (if user adds it, he has to install dothttp-req)
 - [**Bug**] postman import is creating duplicate folder, use showOpenDialog rather than, showSaveDialog
 - [**Bug**] history execute is not showing file extension/ file syntax
 - [**Bug**] history item hove is showing `200 undefined` fixed.
-- [**Improvement**] history item label will be bold and will now start showing time it executed for better difference
-- [**Improvement**] execute quick pick item, will not start showing urls also.
 
 ## [0.0.8]
 - [New] reuse old tab, when executing httpdef target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.0.9]
 - [**Bug**] don't set default python3 path (if user adds it, he has to install dothttp-req)
 - [**Bug**] history execute is not showing file extension/ file syntax
+- [**Bug**] history item hove is showing `200 undefined` fixed.
 - [**Improvement**] history item will now start showing time it executed for better difference
 - [**Improvement**] execute quick pick item, will not start showing urls also.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - [**Bug**] postman import is creating duplicate folder, use showOpenDialog rather than, showSaveDialog
 - [**Bug**] history execute is not showing file extension/ file syntax
 - [**Bug**] history item hove is showing `200 undefined` fixed.
-- [**Improvement**] history item will now start showing time it executed for better difference
+- [**Improvement**] history item label will be bold and will now start showing time it executed for better difference
 - [**Improvement**] execute quick pick item, will not start showing urls also.
 
 ## [0.0.8]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.0.9]
+- [**Bug**] don't set default python3 path (if user adds it, he has to install dothttp-req)
+- [**Bug**] history execute is not showing file extension/ file syntax
+- [**Improvement**] history item will now start showing time it executed for better difference
+- [**Improvement**] execute quick pick item, will not start showing urls also.
+
 ## [0.0.8]
 - [New] reuse old tab, when executing httpdef target
 - [New] format any dictionary/json in httpdef (select dictionary, do `ctrl+1` click format json)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [0.0.9]
+- [Announcement] dothttp-runner can be run in remote wsl and containers.
 - [**Improvement**] history item label will be bold and will now start showing time it executed for better difference
 - [**Improvement**] execute quick pick item, will not start showing urls also.
 - [**Improvement**] Configure response directory name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [0.0.9]
 - [**Bug**] don't set default python3 path (if user adds it, he has to install dothttp-req)
+- [**Bug**] postman import is creating duplicate folder, use showOpenDialog rather than, showSaveDialog
 - [**Bug**] history execute is not showing file extension/ file syntax
 - [**Bug**] history item hove is showing `200 undefined` fixed.
 - [**Improvement**] history item will now start showing time it executed for better difference

--- a/package-lock.json
+++ b/package-lock.json
@@ -195,6 +195,12 @@
 			"integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
 			"dev": true
 		},
+		"@types/lodash": {
+			"version": "4.14.168",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+			"integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==",
+			"dev": true
+		},
 		"@types/mime-types": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "dothttp-code",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -115,12 +115,12 @@
 			},
 			{
 				"command": "dothttpEnvView.enableenv",
-				"title": "enable env",
+				"title": "enable environment",
 				"icon": "$(add)"
 			},
 			{
 				"command": "dothttpEnvView.disableenv",
-				"title": "disable env",
+				"title": "disable environment",
 				"icon": "$(remove)"
 			},
 			{
@@ -155,7 +155,7 @@
 			},
 			{
 				"command": "dothttpEnvView.disableAllEnv",
-				"title": "disable all env",
+				"title": "disable all environment",
 				"icon": "$(close-all)"
 			},
 			{
@@ -170,7 +170,7 @@
 			},
 			{
 				"command": "dothttpEnvView.copyPropertyValue",
-				"title": "copy env property",
+				"title": "copy environment value",
 				"icon": "$(chrome-restore)"
 			}
 		],
@@ -289,6 +289,11 @@
 						"type": "boolean",
 						"default": false,
 						"description": "enable it if reusing old tab while runing requets is preferred"
+					},
+					"dothttp.conf.response.savedirectory": {
+						"type": "string",
+						"default": "./",
+						"description": "provide either absolute path or relative path to current file"
 					},
 					"dothttp.conf.pythonpath": {
 						"type": "string",

--- a/package.json
+++ b/package.json
@@ -373,6 +373,7 @@
 	"devDependencies": {
 		"@types/dateformat": "^3.0.1",
 		"@types/glob": "^7.1.3",
+		"@types/lodash": "^4.14.168",
 		"@types/mime-types": "^2.1.0",
 		"@types/mocha": "^8.0.4",
 		"@types/node": "^12.20.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "dothttp-code",
 	"displayName": "dothttp-code",
 	"description": "run dothttp files in vscode natively",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"publisher": "shivaprasanth",
 	"repository": {
 		"url": "https://github.com/cedric05/dothttp-runner"

--- a/package.json
+++ b/package.json
@@ -292,7 +292,6 @@
 					},
 					"dothttp.conf.pythonpath": {
 						"type": "string",
-						"default": "/usr/bin/python3",
 						"description": "python installation location for making requests"
 					},
 					"dothttp.conf.runrecent": {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -30,9 +30,16 @@ export async function importRequests() {
             placeHolder: "https://getpostman.com/collections"
         });
         if (!link) { return }
-        const folder = await vscode.window.showSaveDialog({
+        const importUri = await vscode.window.showOpenDialog({
+            canSelectFolders: true,
+            canSelectFiles: false,
+            title: "select folder to import resource",
+            canSelectMany: false,
+            openLabel: "select folder to import"
 
         });
+        if (importUri?.length === 0) { return; }
+        const folder = importUri![0];
         if (!folder?.fsPath) { return }
         const directory = folder.fsPath!;
         await vscode.workspace.fs.createDirectory(folder);

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -63,14 +63,14 @@ export async function importRequests() {
 export async function runFileCommand(...arr: any[]) {
     const target = await cacheAndGetTarget(arr);
     if (target) {
-        runHttpFileWithOptions({ curl: false, target: target });
+        return runHttpFileWithOptions({ curl: false, target: target });
     }
 }
 
 export async function genCurlCommand(...arr: any[]) {
     const target = await cacheAndGetTarget(arr);
     if (target) {
-        runHttpFileWithOptions({ curl: true, target: target });
+        return runHttpFileWithOptions({ curl: true, target: target });
     }
 }
 

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -116,15 +116,16 @@ export type TargetSymbolInfo = {
 };
 
 
+export type UrlSymbolInfo = {
+    start: number;
+    url: string;
+    method: string;
+    end: number;
+};
+
 export interface DotTttpSymbol {
     names?: Array<TargetSymbolInfo>,
-    urls?: Array<{
-        start: number,
-        url: string,
-        method: string,
-        end: number
-
-    }>,
+    urls?: Array<UrlSymbolInfo>,
     error?: boolean,
     error_message?: string,
 }

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -78,6 +78,7 @@ export class Configuration {
     configchange = vscode.workspace.onDidChangeConfiguration(() => this.update());
     pythonPath!: string;
     dothttpPath!: string;
+    responseSaveDirectory!: string;
 
 
     private constructor() {
@@ -92,6 +93,7 @@ export class Configuration {
         this.noCookies = vsCodeconfig.get(Constants.nocookie) as boolean
         this.pythonPath = vsCodeconfig.get(Constants.pythonPath) as string;
         this.dothttpPath = vsCodeconfig.get(Constants.dothttpPath) as string;
+        this.responseSaveDirectory = vsCodeconfig.get(Constants.responseDirectory) as string;
     }
 
     public update() {

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -57,7 +57,7 @@ export enum Constants {
     propViewEnabled = "dothttpPropViewEnabled",
 
     // download stuff
-    extensionVersion = "0.0.8",
+    extensionVersion = "0.0.9",
 
     dothttpVersion = "dothttp.version",
 

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -13,6 +13,7 @@ export enum Constants {
     showheaders = "dothttp.conf.showheaders",
     runConf = "dothttp.conf.runrecent",
     reUseOldTab = "dothttp.conf.run.reuseold",
+    responseDirectory = "dothttp.conf.response.savedirectory",
     // view props
 
     // commands

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,15 +1,59 @@
 import * as assert from 'assert';
-
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
+import * as path from 'path';
 import * as vscode from 'vscode';
+import { extensions, Uri } from 'vscode';
+const rangeTestData = require('./rangeTestData.json');
+const testData = require('./testData.json');
+
 // import * as myExtension from '../../extension';
+
+
+const directory: string = path.join(__dirname, "..", "..", "..", "test-resources");
+const filename = path.join(directory, "multidef.http")
+const failFilename = path.join(directory, "fail.http")
 
 suite('Extension Test Suite', () => {
 	vscode.window.showInformationMessage('Start all tests.');
+	const fileUri = Uri.file(path.join(filename));
+	const failFileUri = Uri.file(path.join(failFilename));
 
-	test('Sample test', () => {
-		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
+	suiteSetup(async function () {
+		await extensions.getExtension('shivaprasanth.dothttp-code')!.activate();
+		await vscode.window.showTextDocument(fileUri);
 	});
+
+	test("outline should be present", async () => {
+		const out = await vscode.commands.executeCommand("vscode.executeDocumentSymbolProvider", fileUri) as vscode.SymbolInformation[];
+		const processed = out.map(a => ({ name: a.name, kind: a.kind, location: { range: a.location.range }, containerName: a.containerName }));
+		assert.strictEqual(JSON.stringify(processed), JSON.stringify(testData));
+	})
+
+	test("should provide code lens", async () => {
+		const out = await vscode.commands.executeCommand("vscode.executeCodeLensProvider", failFileUri);
+		assert.strictEqual(JSON.stringify(out), JSON.stringify(rangeTestData));
+	})
+
+
+	// test("should execute and open response result", async () => {
+	// 	return // skipping
+	// 	const args = { target: "first" }
+	// 	//close all windows first
+	// 	await vscode.window.showTextDocument(failFileUri);
+	// 	await Promise.all(vscode.window.visibleTextEditors.map(async editor => {
+	// 		editor.hide();
+	// 	}));
+	// 	await vscode.commands.executeCommand(Constants.runFileCommand, args, args, args);
+	// 	if (vscode.window.visibleTextEditors.filter(edtior => edtior.document.uri.scheme === "untitled").length === 1) {
+	// 		return;
+	// 	}
+	// 	assert.fail("not executed")
+	// })
 });
+
+
+async function sleep(ms: number): Promise<void> {
+	return new Promise(resolve => {
+		setTimeout(resolve, ms);
+	})
+};
+

--- a/src/test/suite/rangeTestData.json
+++ b/src/test/suite/rangeTestData.json
@@ -1,0 +1,122 @@
+[
+	{
+		"range": [
+			{
+				"line": 0,
+				"character": 0
+			},
+			{
+				"line": 1,
+				"character": 29
+			}
+		]
+	},
+	{
+		"range": [
+			{
+				"line": 0,
+				"character": 0
+			},
+			{
+				"line": 1,
+				"character": 29
+			}
+		]
+	},
+	{
+		"range": [
+			{
+				"line": 4,
+				"character": 0
+			},
+			{
+				"line": 8,
+				"character": 2
+			}
+		]
+	},
+	{
+		"range": [
+			{
+				"line": 4,
+				"character": 0
+			},
+			{
+				"line": 8,
+				"character": 2
+			}
+		]
+	},
+	{
+		"range": [
+			{
+				"line": 10,
+				"character": 0
+			},
+			{
+				"line": 14,
+				"character": 2
+			}
+		]
+	},
+	{
+		"range": [
+			{
+				"line": 10,
+				"character": 0
+			},
+			{
+				"line": 14,
+				"character": 2
+			}
+		]
+	},
+	{
+		"range": [
+			{
+				"line": 17,
+				"character": 0
+			},
+			{
+				"line": 19,
+				"character": 28
+			}
+		]
+	},
+	{
+		"range": [
+			{
+				"line": 17,
+				"character": 0
+			},
+			{
+				"line": 19,
+				"character": 28
+			}
+		]
+	},
+	{
+		"range": [
+			{
+				"line": 23,
+				"character": 0
+			},
+			{
+				"line": 28,
+				"character": 1
+			}
+		]
+	},
+	{
+		"range": [
+			{
+				"line": 23,
+				"character": 0
+			},
+			{
+				"line": 28,
+				"character": 1
+			}
+		]
+	}
+];

--- a/src/test/suite/testData.json
+++ b/src/test/suite/testData.json
@@ -1,0 +1,86 @@
+[{
+	"name": "first",
+	"kind": 4,
+	"location": {
+		"range": [
+			{
+				"line": 0,
+				"character": 0
+			},
+			{
+				"line": 1,
+				"character": 29
+			}
+		]
+	},
+	"containerName": ""
+},
+{
+	"name": "second",
+	"kind": 4,
+	"location": {
+		"range": [
+			{
+				"line": 4,
+				"character": 0
+			},
+			{
+				"line": 8,
+				"character": 2
+			}
+		]
+	},
+	"containerName": ""
+},
+{
+	"name": "third",
+	"kind": 4,
+	"location": {
+		"range": [
+			{
+				"line": 10,
+				"character": 0
+			},
+			{
+				"line": 14,
+				"character": 2
+			}
+		]
+	},
+	"containerName": ""
+},
+{
+	"name": "fourth",
+	"kind": 4,
+	"location": {
+		"range": [
+			{
+				"line": 17,
+				"character": 0
+			},
+			{
+				"line": 19,
+				"character": 28
+			}
+		]
+	},
+	"containerName": ""
+},
+{
+	"name": "fifth",
+	"kind": 4,
+	"location": {
+		"range": [
+			{
+				"line": 23,
+				"character": 0
+			},
+			{
+				"line": 28,
+				"character": 1
+			}
+		]
+	},
+	"containerName": ""
+}
+];

--- a/src/utils/text-colors.js
+++ b/src/utils/text-colors.js
@@ -1,0 +1,62 @@
+// copied from 
+// most of it is copied from this file https://github.com/lovasoa/html2unicode/blob/master/src/index.js
+// please refer above repository for license.
+
+
+function transform(text, { bold, italics, mono, variable, sub, sup }) {
+    text = text.normalize("NFKD");
+    if (sub) text = subscript(text);
+    else if (sup) text = superscript(text);
+    else if (bold && italics) text = boldenAndItalicize(text);
+    else if (bold) text = bolden(text);
+    else if (italics) text = italicize(text);
+    else if (mono) text = monospace(text);
+    else if (variable) text = scriptize(text);
+    return text;
+}
+
+class CharTransform {
+    constructor(startLetter, endLetter, startReplacement) {
+        this.startCode = startLetter.charCodeAt(0);
+        this.endCode = endLetter.charCodeAt(0);
+        this.replacementCodes = startReplacement.split('').map(c => c.charCodeAt(0));
+    }
+
+    matches(charCode) {
+        return charCode >= this.startCode && charCode <= this.endCode;
+    }
+
+    transform(charCode, buffer) {
+        buffer.push(...this.replacementCodes);
+        buffer[buffer.length - 1] += charCode - this.startCode;
+    }
+}
+
+class SmallLetterTransform extends CharTransform {
+    constructor(startReplacement) {
+        super('a', 'z', startReplacement);
+    }
+}
+
+class CapitalLetterTransform extends CharTransform {
+    constructor(startReplacement) {
+        super('A', 'Z', startReplacement);
+    }
+}
+
+class DigitTransform extends CharTransform {
+    constructor(startReplacement) {
+        super('0', '9', startReplacement);
+    }
+}
+
+
+CharTransform.boldenTransforms = [
+    new CapitalLetterTransform('𝗔'),
+    new SmallLetterTransform('𝗮'),
+    new DigitTransform('𝟬'),
+];
+
+const bolden = transformator(CharTransform.boldenTransforms);
+
+module.exports = transform

--- a/src/utils/text-colors.js
+++ b/src/utils/text-colors.js
@@ -57,6 +57,19 @@ CharTransform.boldenTransforms = [
     new DigitTransform('𝟬'),
 ];
 
+function transformator(transforms) {
+    return function transform(text) {
+        let codesBuffer = [];
+        for (let i = 0; i < text.length; i++) {
+            let code = text.charCodeAt(i);
+            const transform = transforms.find(t => t.matches(code));
+            if (transform) transform.transform(code, codesBuffer);
+            else codesBuffer.push(code);
+        }
+        return String.fromCharCode(...codesBuffer);
+    };
+}
+
 const bolden = transformator(CharTransform.boldenTransforms);
 
 module.exports = transform

--- a/src/views/historytree.ts
+++ b/src/views/historytree.ts
@@ -4,7 +4,7 @@ import { history, IHistoryService } from "../tingohelpers";
 import DotHttpEditorView from "./editor";
 import dateFormat = require("dateformat");
 import querystring = require('querystring');
-const transform = require('../utils/text-colors.js');
+import transform from '../utils/text-colors';
 
 enum TreeType {
     recent,

--- a/src/views/historytree.ts
+++ b/src/views/historytree.ts
@@ -37,6 +37,7 @@ export class HistoryTreeProvider implements TreeDataProvider<HistoryTreeItem> {
     fetcedCount: number = 0;
 
     private readonly dateFormat = "yyyy-mm-dd";
+    private readonly historyItemFormat = "hh:MM";
 
     constructor() {
         this.map.set('recent', []);
@@ -84,8 +85,10 @@ export class HistoryTreeProvider implements TreeDataProvider<HistoryTreeItem> {
                 iconType = historyItemicons.STATUS_ISSUE
                 command = null
             }
+
+            const hourAndMinutes = dateFormat(item.time, this.historyItemFormat);
             const tree = {
-                label: `${path.basename(item.filename)} #${item.target}`,
+                label: `${path.basename(item.filename)} #${item.target} ${hourAndMinutes}`,
                 command: command,
                 iconPath: iconType,
                 tooltip: `${item.status_code} ${item.url}`,
@@ -121,7 +124,7 @@ export class HistoryTreeProvider implements TreeDataProvider<HistoryTreeItem> {
     }
 
 
-    private async fetchMore(loadCount=100) {
+    private async fetchMore(loadCount = 100) {
         const historyItems = await this.historyService.fetchMore(this.fetcedCount, loadCount);
         this.fetcedCount += historyItems.length;
         const recent = dateFormat(new Date(), this.dateFormat);

--- a/src/views/historytree.ts
+++ b/src/views/historytree.ts
@@ -4,6 +4,7 @@ import { history, IHistoryService } from "../tingohelpers";
 import DotHttpEditorView from "./editor";
 import dateFormat = require("dateformat");
 import querystring = require('querystring');
+const transform = require('../utils/text-colors.js');
 
 enum TreeType {
     recent,
@@ -87,8 +88,9 @@ export class HistoryTreeProvider implements TreeDataProvider<HistoryTreeItem> {
             }
 
             const hourAndMinutes = dateFormat(item.time, this.historyItemFormat);
+
             const tree = {
-                label: `${path.basename(item.filename)} #${item.target} ${hourAndMinutes}`,
+                label: transform(`${path.basename(item.filename)} #${item.target} `, { bold: true }) + hourAndMinutes,
                 command: command,
                 iconPath: iconType,
                 tooltip: `${item.status_code} ${item.url ?? ''}`,

--- a/src/views/historytree.ts
+++ b/src/views/historytree.ts
@@ -91,7 +91,7 @@ export class HistoryTreeProvider implements TreeDataProvider<HistoryTreeItem> {
                 label: `${path.basename(item.filename)} #${item.target} ${hourAndMinutes}`,
                 command: command,
                 iconPath: iconType,
-                tooltip: `${item.status_code} ${item.url}`,
+                tooltip: `${item.status_code} ${item.url ?? ''}`,
             } as TreeItem;
             return tree;
         } else {

--- a/test-resources/fail.http
+++ b/test-resources/fail.http
@@ -1,0 +1,1 @@
+GET "http00://fail"

--- a/test-resources/multidef.http
+++ b/test-resources/multidef.http
@@ -1,0 +1,29 @@
+@name('first')
+GET "https://req.dothttp.dev"
+
+
+@name('second')
+POST "https://req.dothttp.dev"
+json({
+    "test": "this is payload"
+})
+
+@name('third')
+POST "https://req.dothttp.dev"
+data({
+    "test": "this is payload"
+})
+
+
+@name('fourth')
+POST "https://req.dothttp.dev"
+data("this is text payload")
+
+
+
+@name('fifth')
+POST "https://req.dothttp.dev"
+files(
+    ('name', "this is multipart"),
+    ('name2', "this is multipart")
+)


### PR DESCRIPTION
-  [**Improvement**] history item will now start showing time it executed for better difference
-  [**Improvement**] execute quick pick item, will not start showing urls also. 
- [**announcement**] dothttp-runner can be run in remote wsl and containers. 
- [**Improvement**] Configure response directory name.
-  [**Bug**] don't set default python3 path (if user adds it, he has to install dothttp-req)
-  [**Bug**] postman import is creating duplicate folder, use showOpenDialog rather than, showSaveDialog
-  [**Bug**] history execute is not showing file extension/ file syntax 
-  [**Bug**] history item hove is showing `200 undefined` fixed.