### PR TITLE
dothttp-runner  v0.0.27 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## [0.0.27]
 
-This is a minor update
-
 - [**Improvement**] Editor commands now more approachable (now available in editor context)
-- [**Improvement**] Generate request programming language is including "gen..py" fix
+- [**Fix**] `Generate request programming language` is generating file name with extension (two dots) "gen..py"
+- [**Improvement**] export postman now generates filename with suffix ".postmancollection.json" 
+- [**New Feature**] supports importing har file
+- [**Improvement**] curl with new library and import by file, should fix most curl import issues
+  - Use other formats as curl import os not standardised
+- [**Improvement**] Now `dothttp history`, `dothttp environment` and `dothttp propertiles` will be shown in seperate view container for easy access
+
 
 
 ## [0.0.26]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [0.0.27]
+
+This is a minor update
+
+- [**Improvement**] Editor commands now more approachable (now available in editor context)
+- [**Improvement**] Generate request programming language is including "gen..py" fix
+
+
 ## [0.0.26]
 
 - [**Improvement**] dothttp completions

--- a/package-lock.json
+++ b/package-lock.json
@@ -684,6 +684,21 @@
 				"sprintf-js": "~1.0.2"
 			}
 		},
+		"array-filter": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+			"integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
+		},
+		"array-map": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+			"integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
+		},
+		"array-reduce": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+			"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
+		},
 		"array-union": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -1308,6 +1323,40 @@
 				"shell-quote": "^1.4.3",
 				"underscore": "^1.8.3",
 				"underscore.string": "^3.0.3"
+			}
+		},
+		"curl-to-postmanv2": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/curl-to-postmanv2/-/curl-to-postmanv2-0.5.1.tgz",
+			"integrity": "sha512-XzS4EfUX8a6ZindDwLM6yN+yLtAJGQGRGghsHj4Yp7xZ4Mz7nK+7qZXnHVF4e7hARKhP+kYsLjc+ZsODUVUb4A==",
+			"requires": {
+				"commander": "2.15.1",
+				"lodash": "^4.17.11",
+				"shell-quote": "1.6.1",
+				"uuid": "3.2.1"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.15.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+				},
+				"shell-quote": {
+					"version": "1.6.1",
+					"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+					"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+					"requires": {
+						"array-filter": "~0.0.0",
+						"array-map": "~0.0.0",
+						"array-reduce": "~0.0.0",
+						"jsonify": "~0.0.0"
+					}
+				},
+				"uuid": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+					"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+				}
 			}
 		},
 		"dateformat": {
@@ -2366,6 +2415,11 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
 			"integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA=="
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
 		},
 		"kind-of": {
 			"version": "6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "dothttp-code",
-	"version": "0.0.26",
+	"version": "0.0.27",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -282,9 +282,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.57.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.57.0.tgz",
-			"integrity": "sha512-FeznBFtIDCWRluojTsi9c3LLcCHOXP5etQfBK42+ixo1CoEAchkw39tuui9zomjZuKfUVL33KZUDIwHZ/xvOkQ=="
+			"version": "1.59.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.59.0.tgz",
+			"integrity": "sha512-Zg38rusx2nU6gy6QdF7v4iqgxNfxzlBlDhrRCjOiPQp+sfaNrp3f9J6OHIhpGNN1oOAca4+9Hq0+8u3jwzPMlQ=="
 		},
 		"@types/vscode-notebook-renderer": {
 			"version": "1.57.9",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "dothttp-code",
 	"displayName": "Dothttp Http Client",
 	"description": "A Http Client for sending to and receiving from http endpoints (dothttp)",
-	"version": "0.0.26",
+	"version": "0.0.27",
 	"license": "Apache-2.0",
 	"publisher": "shivaprasanth",
 	"repository": {
@@ -169,7 +169,7 @@
 			},
 			{
 				"command": "dothttp.command.import.external",
-				"title": "Import Resource To Http",
+				"title": "Dothttp Import Resource To Http",
 				"category": "Dothttp",
 				"icon": "$(cloud-download)"
 			},
@@ -240,17 +240,17 @@
 			},
 			{
 				"command": "dothttp.command.generatelang",
-				"title": "Dothttp generate request Programming Languages",
+				"title": "Dothttp Generate General Programming Languages For Request",
 				"icon": "$(extensions)"
 			},
 			{
 				"command": "dothttp.command.restartcli",
-				"title": "Dothttp restart cli server",
+				"title": "Dothttp Restart Cli Server",
 				"icon": "$(debug-restart)"
 			},
 			{
 				"command": "dothttp.command.export.postman",
-				"title": "Dothttp export http to postman",
+				"title": "Dothttp Export Http To Postman",
 				"icon": "$(extensions)"
 			}
 		],
@@ -271,7 +271,26 @@
 				{
 					"command": "dothttp.command.export.postman",
 					"title": "Dothttp export http to postman",
+					"group": "Dothttp",
 					"icon": "$(extensions)"
+				},
+				{
+					"command": "dothttp.command.import.external",
+					"title": "Dothttp Import Resource To Http",
+					"group": "Dothttp",
+					"icon": "$(cloud-download)"
+				},
+				{
+					"command": "dothttp.command.generatelang",
+					"title": "Dothttp Generate General Programming Languages For Request",
+					"group": "Dothttp",
+					"icon": "$(extensions)"
+				},
+				{
+					"command": "dothttp.command.run",
+					"title": "Dothttp Run Target",
+					"icon": "$(rocket)",
+					"category": "Dothttp"
 				}
 			],
 			"commandPalette": [
@@ -497,7 +516,7 @@
 	"dependencies": {
 		"axios": "^0.21.1",
 		"curl-to-har": "^1.0.1",
-		"@types/vscode": "^1.57.0",
+		"@types/vscode": "^1.59.0",
 		"dateformat": "^4.5.1",
 		"httpsnippet": "^1.25.0",
 		"json-stringify-safe": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -445,7 +445,7 @@
 			}
 		],
 		"views": {
-			"explorer": [
+			"dothttp-view-container": [
 				{
 					"id": "dothttpEnvView",
 					"name": "Dothttp Environment",
@@ -459,6 +459,15 @@
 				{
 					"id": "dothttpHistory",
 					"name": "Dothttp history"
+				}
+			]
+		},
+		"viewsContainers": {
+			"activitybar": [
+				{
+					"id": "dothttp-view-container",
+					"title": "Package Explorer",
+					"icon": "$(rocket)"
 				}
 			]
 		},

--- a/package.json
+++ b/package.json
@@ -514,9 +514,10 @@
 		"webpack-cli": "^4.5.0"
 	},
 	"dependencies": {
+		"@types/vscode": "^1.59.0",
 		"axios": "^0.21.1",
 		"curl-to-har": "^1.0.1",
-		"@types/vscode": "^1.59.0",
+		"curl-to-postmanv2": "^0.5.1",
 		"dateformat": "^4.5.1",
 		"httpsnippet": "^1.25.0",
 		"json-stringify-safe": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -466,7 +466,7 @@
 			"activitybar": [
 				{
 					"id": "dothttp-view-container",
-					"title": "Package Explorer",
+					"title": "Dothttp",
 					"icon": "$(rocket)"
 				}
 			]

--- a/src/extension/commands/generate.ts
+++ b/src/extension/commands/generate.ts
@@ -66,7 +66,7 @@ export async function generateLang(...arr: any[]) {
             indent: '\t'
         });
         // TODO only gives out python file name now.
-        const outputBodyURI = vscode.Uri.parse("untitled:" + filename + ".gen." + pickLanguage.filext);
+        const outputBodyURI = vscode.Uri.parse("untitled:" + filename + ".gen" + pickLanguage.filext);
         vscode.workspace.openTextDocument(outputBodyURI).then((textDoc) => {
             showEditor(textDoc, langSpec as string);
         });

--- a/src/extension/commands/run.ts
+++ b/src/extension/commands/run.ts
@@ -125,6 +125,10 @@ async function importCurl(version: string) {
             placeHolder: "curl -X <link>",
         });
     }
+    if (!curlStatement) {
+        // don't process if user hasn't pasted any thing
+        return
+    }
     // problem with multiline curl
     // inputopions is removing all new line chars
     // which is causing this mitigation

--- a/src/extension/commands/run.ts
+++ b/src/extension/commands/run.ts
@@ -146,7 +146,7 @@ export async function exportToPostman() {
             return;
         }
         const collection = result.collection;
-        const uri = vscode.Uri.parse("untitled:" + doc.fileName + ".json");
+        const uri = vscode.Uri.parse("untitled:" + doc.fileName + ".postman_collection.json");
         const collectionDoc = await vscode.workspace.openTextDocument(uri);
         showEditor(collectionDoc, JSON.stringify(collection));
     }

--- a/src/extension/commands/run.ts
+++ b/src/extension/commands/run.ts
@@ -56,7 +56,7 @@ function curltoHarUsingpostmanconverter(statmenet: string) {
                 obj.header.forEach((element: { key: string; value: string; }) => {
                     headers[element.key.toLowerCase()] = element.value.toLowerCase();
                 });
-                if (headers['content-type'].indexOf("application/json"))
+                if (headers['content-type'].indexOf("application/json") > -1)
                     postData!.mimeType = "application/json"
                 else
                     postData!.mimeType = "text/plain"

--- a/src/extension/lib/client.ts
+++ b/src/extension/lib/client.ts
@@ -274,7 +274,7 @@ export class ClientHandler {
         })
     }
 
-    async importHarToFromHar(har: {}, save_directory: string, save_filename?: string): Promise<ImportHarResult> {
+    async importHttpFromHar(har: {}, save_directory: string, save_filename?: string): Promise<ImportHarResult> {
         return await this.cli.request(ClientHandler.HAR_IMPORT_COMMAND, {
             har, save_directory, save_filename
         })

--- a/src/extension/models/constants.ts
+++ b/src/extension/models/constants.ts
@@ -70,7 +70,7 @@ export enum Constants {
     NOTEBOOK_ID = 'dothttp-book',
 
     // download stuff
-    EXTENSION_VERSION = "0.0.26",
+    EXTENSION_VERSION = "0.0.27",
 
     dothttpNotebook = "dothttp-book",
 


### PR DESCRIPTION
## [0.0.27]

- [**Improvement**] Editor commands now more approachable (now available in editor context)
- [**Fix**] `Generate request programming language` is generating file name with extension (two dots) "gen..py"
- [**Improvement**] export postman now generates filename with suffix ".postmancollection.json" 
- [**New Feature**] supports importing har file
- [**Improvement**] curl with new library and import by file, should fix most curl import issues
  - Use other formats as curl import os not standardised
- [**Improvement**] Now `dothttp history`, `dothttp environment` and `dothttp propertiles` will be shown in seperate view container for easy access


