### PR TITLE
Script boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [**bump**] swagger-to-har2 to 1.0.4
   - fixes openapi3 import request payloads
 - [**Bug**] swagger import is not showing '.yml' files while import
+- [**Bug**] renaming target in notebook or reording notebook is causing failure with `incorrect target`  fixed
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 ## Known issues
 - notebook search with `m` or `y` in key won't work, as vscode configured default shortcut `m` to change cell to markdown and is annoying. [remove](https://code.visualstudio.com/docs/getstarted/keybindings#_keyboard-shortcuts-editor) `m` and `y` shortcuts for clean experience.
 
+## [0.0.38]
+- [**Improvement**] better code outline and easy filtering 
+  - use '^' to filter urls
+  - use '#' to filter by name
+- [**Improvement**] test script completion provided using request forwarding to javascript.
+- [**Improvement**] bump dothttp version to 0.0.40a2
+
+
+
+
 ## [0.0.37]
 
 - [**New**] added `create new notebook command`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - supports script suggestions
 - [**bump**] swagger-to-har2 to 1.0.4
   - fixes openapi3 import request payloads
+- [**Bug**] swagger import is not showing '.yml' files while import
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@
   - use '^' to filter urls
   - use '#' to filter by name
 - [**Improvement**] test script completion provided using request forwarding to javascript.
-- [**Improvement**] bump dothttp version to 0.0.40a2
+- [**bump**] dothttp version to 0.0.40a2
+  - supports script suggestions
+- [**bump**] swagger-to-har2 to 1.0.4
+  - fixes openapi3 import request payloads
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3852,9 +3852,9 @@
 			}
 		},
 		"swagger-to-har2": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/swagger-to-har2/-/swagger-to-har2-1.0.3.tgz",
-			"integrity": "sha512-sJWG3wjSoptwaozXmktIpZ2y50Vur5p3PhlVmK1LCdfv+caXw0m3l3GP99xb9S8rnVg0G8a3XjtyEVQfRoqnWA==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/swagger-to-har2/-/swagger-to-har2-1.0.4.tgz",
+			"integrity": "sha512-8wNAD9Vrk20d15LXG9h9mx30j1ChfJUdfe65SuzY7K/VF5mxa8iEqNAtYkn7kRJSHDXBkKmD0HUnMdvUWnxc8g==",
 			"requires": {
 				"@stoplight/json-schema-sampler": "^0.2.0",
 				"json-schema-instantiator": "0.4.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "dothttp-code",
-	"version": "0.0.37",
+	"version": "0.0.38",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -728,7 +728,7 @@
 		"mime-types": "^2.1.30",
 		"path-browserify": "^1.0.1",
 		"semver": "^7.3.4",
-		"swagger-to-har2": "^1.0.3",
+		"swagger-to-har2": "^1.0.4",
 		"temp": "^0.9.4",
 		"tingodb": "^0.6.1",
 		"unzipper": "^0.10.11",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "dothttp-code",
 	"displayName": "Dothttp Http Client",
 	"description": "A Http Client for sending to and receiving from http endpoints (dothttp)",
-	"version": "0.0.37",
+	"version": "0.0.38",
 	"license": "Apache-2.0",
 	"publisher": "shivaprasanth",
 	"repository": {

--- a/src/extension/commands/import.ts
+++ b/src/extension/commands/import.ts
@@ -248,7 +248,7 @@ export async function importRequests() {
             } else if (linkOrFileType === 'file') {
                 const filters: { [ram: string]: any; } = {};
                 if (pickType === ImportOptions.swagger) {
-                    filters.Swagger = ["json", "yaml"];
+                    filters.Swagger = ["json", "yaml", "yml"];
                 } else if (pickType === ImportOptions.har) {
                     filters.har = ["har", "har.json", "json"];
                 } else {

--- a/src/extension/editorIntellisense.ts
+++ b/src/extension/editorIntellisense.ts
@@ -238,12 +238,14 @@ export class DothttpNameSymbolProvider implements vscode.CodeLensProvider<Dothtt
                     })
             }
             return (result.names ?? []).map(element =>
-                new SymbolInformation(element.name, vscode.SymbolKind.Class,
+                // gives feasibilty to filter just url targets names
+                new SymbolInformation("#" + element.name, vscode.SymbolKind.Class,
                     new Range(
                         document.positionAt(element.start),
                         document.positionAt(element.end)),
                 )).concat((result.urls ?? []).map(element =>
-                    new SymbolInformation(element.method + " " + element.url, vscode.SymbolKind.Field,
+                // gives feasibilty to filter just url
+                    new SymbolInformation("^" + element.url + " -- " + element.method, vscode.SymbolKind.Field,
                         new Range(
                             document.positionAt(element.start),
                             document.positionAt(element.end)),

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -112,11 +112,11 @@ export async function activate(context: vscode.ExtensionContext) {
 		vscode.window.registerTreeDataProvider(Constants.dothttpHistory, appServices.getHistoryTreeProvider()),
 
 
-		// vscode.languages.registerCompletionItemProvider(Constants.LANG_CODE, new UrlCompletionProvider(), ...UrlCompletionProvider.triggerCharacters),
-		// vscode.languages.registerCompletionItemProvider(Constants.LANG_CODE, new VariableCompletionProvider(), ...VariableCompletionProvider.triggerCharacters),
-		// vscode.languages.registerCompletionItemProvider(Constants.LANG_CODE, new HeaderCompletionItemProvider(), ...HeaderCompletionItemProvider.triggerCharacters),
+		vscode.languages.registerCompletionItemProvider(Constants.LANG_CODE, new UrlCompletionProvider(), ...UrlCompletionProvider.triggerCharacters),
+		vscode.languages.registerCompletionItemProvider(Constants.LANG_CODE, new VariableCompletionProvider(), ...VariableCompletionProvider.triggerCharacters),
+		vscode.languages.registerCompletionItemProvider(Constants.LANG_CODE, new HeaderCompletionItemProvider(), ...HeaderCompletionItemProvider.triggerCharacters),
 
-		// vscode.languages.registerCompletionItemProvider(Constants.LANG_CODE, new KeywordCompletionItemProvider(), ...KeywordCompletionItemProvider.triggerCharacters),
+		vscode.languages.registerCompletionItemProvider(Constants.LANG_CODE, new KeywordCompletionItemProvider(), ...KeywordCompletionItemProvider.triggerCharacters),
 		vscode.languages.registerCompletionItemProvider(Constants.LANG_CODE, new ScriptCompletionProvider())
 
 	]);

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { workspace } from 'vscode';
 import { copyProperty, disableCommand, enableCommand, toggleExperimentalFlag } from './commands/enable';
 import { generateLangForHttpFile } from "./commands/export/generate";
 import { exportToPostman } from "./commands/export/postman";
@@ -11,7 +12,7 @@ import {
 	UrlExpander
 } from './editorIntellisense';
 import { Constants } from './models/constants';
-import { HeaderCompletionItemProvider, KeywordCompletionItemProvider, UrlCompletionProvider, VariableCompletionProvider } from './services/dothttpCompletion';
+import { HeaderCompletionItemProvider, KeywordCompletionItemProvider, ScriptCompletionProvider, UrlCompletionProvider, VariableCompletionProvider } from './services/dothttpCompletion';
 import { ApplicationServices } from './services/global';
 import { NotebookKernel } from './services/notebook';
 import DotHttpEditorView from './views/editor';
@@ -111,12 +112,24 @@ export async function activate(context: vscode.ExtensionContext) {
 		vscode.window.registerTreeDataProvider(Constants.dothttpHistory, appServices.getHistoryTreeProvider()),
 
 
-		vscode.languages.registerCompletionItemProvider(Constants.LANG_CODE, new UrlCompletionProvider(), ...UrlCompletionProvider.triggerCharacters),
-		vscode.languages.registerCompletionItemProvider(Constants.LANG_CODE, new VariableCompletionProvider(), ...VariableCompletionProvider.triggerCharacters),
-		vscode.languages.registerCompletionItemProvider(Constants.LANG_CODE, new HeaderCompletionItemProvider(), ...HeaderCompletionItemProvider.triggerCharacters),
+		// vscode.languages.registerCompletionItemProvider(Constants.LANG_CODE, new UrlCompletionProvider(), ...UrlCompletionProvider.triggerCharacters),
+		// vscode.languages.registerCompletionItemProvider(Constants.LANG_CODE, new VariableCompletionProvider(), ...VariableCompletionProvider.triggerCharacters),
+		// vscode.languages.registerCompletionItemProvider(Constants.LANG_CODE, new HeaderCompletionItemProvider(), ...HeaderCompletionItemProvider.triggerCharacters),
 
-		vscode.languages.registerCompletionItemProvider(Constants.LANG_CODE, new KeywordCompletionItemProvider(), ...KeywordCompletionItemProvider.triggerCharacters),
+		// vscode.languages.registerCompletionItemProvider(Constants.LANG_CODE, new KeywordCompletionItemProvider(), ...KeywordCompletionItemProvider.triggerCharacters),
+		vscode.languages.registerCompletionItemProvider(Constants.LANG_CODE, new ScriptCompletionProvider())
+
 	]);
+
+	workspace.registerTextDocumentContentProvider('embedded-content', {
+		provideTextDocumentContent: uri => {
+			const originalUri = uri.path.slice(1).slice(0, -3);
+			const map = ApplicationServices.get().embeddedContent;
+			console.log(`recv url uri ${originalUri}`);
+			const content = map.get(originalUri);
+			return content;
+		}
+	});
 
 
 

--- a/src/extension/models/constants.ts
+++ b/src/extension/models/constants.ts
@@ -77,7 +77,7 @@ export enum Constants {
     NOTEBOOK_ID = 'dothttp-book',
 
     // download stuff
-    EXTENSION_VERSION = "0.0.37",
+    EXTENSION_VERSION = "0.0.38",
 
     dothttpNotebook = "dothttp-book",
 

--- a/src/extension/services/global.ts
+++ b/src/extension/services/global.ts
@@ -32,6 +32,7 @@ export class ApplicationServices {
     private urlStore: UrlStore;
     private notebookkernel!: NotebookKernel;
     private context: vscode.ExtensionContext;
+    embeddedContent: Map<string, string>;
 
     constructor(context: vscode.ExtensionContext) {
         this.storageService = new LocalStorageService(context.workspaceState);
@@ -54,6 +55,7 @@ export class ApplicationServices {
         this.versionInfo = new VersionInfo(this.globalstorageService);
         this.config = Configuration.instance();
         this.context = context;
+        this.embeddedContent = new Map<string, string>();
         context.subscriptions.push(this.diagnostics);
     }
 
@@ -80,6 +82,10 @@ export class ApplicationServices {
         this.dothttpSymbolProvier.setClientHandler(this.clientHanler);
         this.dothttpSymbolProvier.setDiagnostics(this.diagnostics);
 
+    }
+
+    public setEmbeddedContent(uri: string, content: string) {
+        this.embeddedContent.set(uri, content);
     }
 
     getClientHandler(): ClientHandler {


### PR DESCRIPTION
## [0.0.38]
- [**Improvement**] better code outline and easy filtering 
  - use '^' to filter URLs
  - use '#' to filter by name
- [**Improvement**] test script completion provided using request forwarding to JavaScript.
- [**bump**] Dothttp version to 0.0.40a2
  - supports script suggestions
- [**bump**] swagger-to-har2 to 1.0.4
  - fixes openapi3 import request payloads
- [**Bug**] swagger import is not showing '.yml' files while import
- [Bug] renaming target in notebook or reording notebook is causing failure with incorrect target fixed