### PR TITLE
Draft: Remote FS (Fallback Mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Known issues
 - notebook search with `m` or `y` in key won't work, as vscode configured default shortcut `m` to change cell to markdown and is annoying. [remove](https://code.visualstudio.com/docs/getstarted/keybindings#_keyboard-shortcuts-editor) `m` and `y` shortcuts for clean experience.
 
+## 1.0.53
+- Update `dotextensions-build` to version 0.0.44a18
+- Property view will not show duplicate keys, will let you pick one you want
+- incase of cli exited, it will retry
+- Incase cli is running in some remote machine, will let you use remote cli capabilities edit (not recommended for full fledged) 
+
 ## 1.0.52
 - Update `dotextensions-build` to version 0.0.44a15
   - Now Supports array indexing in variable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 - notebook search with `m` or `y` in key won't work, as vscode configured default shortcut `m` to change cell to markdown and is annoying. [remove](https://code.visualstudio.com/docs/getstarted/keybindings#_keyboard-shortcuts-editor) `m` and `y` shortcuts for clean experience.
 
 ## 1.0.53
-- Update `dotextensions-build` to version 0.0.44a18
-- Property view will not show duplicate keys, will let you pick one you want
-- incase of cli exited, it will retry
-- Incase cli is running in some remote machine, will let you use remote cli capabilities edit (not recommended for full fledged) 
+- Updated dotextensions-build to version 0.0.44a18.
+- Property view now prevents duplicate keys and allows you to select the one you want.
+- Automatically retries if the CLI exits unexpectedly.
+- Added support for using CLI capabilities from a remote machine (not recommended for full-fledged editing).
+
 
 ## 1.0.52
 - Update `dotextensions-build` to version 0.0.44a15

--- a/package.json
+++ b/package.json
@@ -844,6 +844,11 @@
 					"when": "scmProvider == git",
 					"group": "dothttp"
 				}
+			],
+			"statusBar/windowIndicator": [
+				{
+					"command": "dothttp.command.openFolderInRemote"
+				}
 			]
 		},
 		"configuration": [
@@ -928,6 +933,13 @@
 				"type": "dothttp"
 			}
 		],
+		"remoteHelp": {
+			"documentation": "https://dothttp.dev/docs",
+			"feedback": "https://github.com/cedric05/dothttp-runner/issues",
+			"issues": "https://github.com/cedric05/dothttp-runner/issues",
+			"getStarted": "https://dothttp.dev/docs",
+			"reportIssue": "https://github.com/cedric05/dothttp-runner/issues"
+		},
 		"views": {
 			"dothttp-view-container": [
 				{

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "dothttp-code",
 	"displayName": "Dothttp",
 	"description": "A Http Client for sending to and receiving from http endpoints (dothttp)",
-	"version": "1.0.52",
+	"version": "1.0.53",
 	"license": "Apache-2.0",
 	"publisher": "shivaprasanth",
 	"repository": {
@@ -33,6 +33,7 @@
 		"Other"
 	],
 	"activationEvents": [
+		"onFileSystem:memfs",
 		"onNotebook:dothttp-book",
 		"onLanguage:dothttp-vscode",
 		"workspaceContains:**/*.http",
@@ -183,6 +184,13 @@
 				"category": "Dothttp",
 				"icon": "$(new-file)",
 				"enablement": "dothttpRunMode == full"
+			},
+			{
+				"command": "dothttp.command.openFolderInRemote",
+				"title": "Dothttp: Open folder in remote",
+				"shortTitle": "Open folder in remote",
+				"category": "Dothttp",
+				"icon": "$(remote-explorer)"
 			},
 			{
 				"command": "dothttp.command.createHnbkFile",
@@ -556,6 +564,11 @@
 			],
 			"commandPalette": [
 				{
+					"group": "dothttp",
+					"command": "dothttp.command.openFolderInRemote",
+					"when": "dothttpRunMode == full"
+				},
+				{
 					"group": "toggle",
 					"command": "dothttp.command.toggle.reuse",
 					"when": "dothttpRunMode == full"
@@ -854,7 +867,7 @@
 					},
 					"dothttp.conf.diagnostics": {
 						"type": "boolean",
-						"default": false,
+						"default": true,
 						"description": "Enables error diagnostics"
 					},
 					"dothttp.conf.pythonpath": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"Other"
 	],
 	"activationEvents": [
-		"onFileSystem:memfs",
+		"onFileSystem:dothttpfs",
 		"onNotebook:dothttp-book",
 		"onLanguage:dothttp-vscode",
 		"workspaceContains:**/*.http",
@@ -187,7 +187,7 @@
 			},
 			{
 				"command": "dothttp.command.openFolderInRemote",
-				"title": "Dothttp: Open folder in remote",
+				"title": "Open folder in remote",
 				"shortTitle": "Open folder in remote",
 				"category": "Dothttp",
 				"icon": "$(remote-explorer)"

--- a/src/extension/downloader.ts
+++ b/src/extension/downloader.ts
@@ -40,7 +40,7 @@ export async function getLaunchArgs(context: ExtensionContext): Promise<ClientLa
         "cli",
         getCliWithExtension(),
     ).fsPath;
-    for (const [lookupLocation, assumedPath] of Object.entries({ extensionWithPath: cliWithExtension, configureddothttpPath, workspacedothttPath, defaultPath: defaultExePath })) {
+    for (const [lookupLocation, assumedPath] of Object.entries({ configureddothttpPath, extensionWithPath: cliWithExtension, workspacedothttPath, defaultPath: defaultExePath })) {
         console.log(`checking ${lookupLocation}: ${assumedPath}`);
         if (assumedPath && fs.existsSync(assumedPath)) {
             console.log(`working ${lookupLocation}: ${assumedPath}`);

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -74,7 +74,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	const fileSystemProvider = new SimpleFsProvider(clientHandler);
 	context.subscriptions.push(
-		vscode.workspace.registerFileSystemProvider('memfs', fileSystemProvider, { isCaseSensitive: true })
+		vscode.workspace.registerFileSystemProvider('dothttpfs', fileSystemProvider, { isCaseSensitive: true })
 	);
 
 	const appServices = new ApplicationBuilder()
@@ -273,7 +273,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	// new command which connects to remote folder
 	vscode.commands.registerCommand(Constants.OPEN_FODLER_IN_REMOTE, async () => {
 		await lazy_load;
-		const rootUri = vscode.Uri.parse('memfs:/');
+		const rootUri = vscode.Uri.parse('dothttpfs:/');
 		const selectedUri = await selectDirectory(fileSystemProvider, rootUri);
 		if (selectedUri) {
 			await vscode.commands.executeCommand('vscode.openFolder', selectedUri, { forceReuseWindow: true });

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -284,7 +284,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 async function selectDirectory(fsProvider: SimpleFsProvider, currentUri: vscode.Uri): Promise<vscode.Uri | undefined> {
 	const filelist = await fsProvider.readDirectory(currentUri);
-	const directories = filelist.filter(([name, type]) => type === vscode.FileType.Directory).map(([name, type]) => name);
+	const directories = filelist.filter(([_name, type]) => type === vscode.FileType.Directory).map(([name, _type]) => name);
 
 	const folder = await vscode.window.showQuickPick(directories.concat(['..']), {
 		placeHolder: currentUri.path,

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -34,6 +34,7 @@ import { Constants } from './web/utils/constants';
 import { ProNotebookKernel } from './native/services/notebookkernel';
 import * as fs from 'fs'
 import { VscodeOutputChannelWrapper } from './native/services/languageservers/channelWrapper';
+import { SimpleFsProvider } from './native/services/fsprovider';
 const path = require('path');
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -70,6 +71,12 @@ export async function activate(context: vscode.ExtensionContext) {
 	const configInstance = Configuration.instance();
 	const channelWrapper = new VscodeOutputChannelWrapper(configInstance);
 	notebookKernel.configure(clientHandler2, fileStateService, propertyTree, configInstance);
+
+	const fileSystemProvider = new SimpleFsProvider(clientHandler);
+	context.subscriptions.push(
+		vscode.workspace.registerFileSystemProvider('memfs', fileSystemProvider, { isCaseSensitive: true })
+	);
+
 	const appServices = new ApplicationBuilder()
 		.setStorageService(storageService)
 		.setGlobalstorageService(globalStorageService)
@@ -91,7 +98,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		.setHistoryTreeProvider(historyTreeProvider)
 		.build();
 
-	bootStrap(appServices); // lazy loading
+	const lazy_load = bootStrap(appServices); // lazy loading
 	loadNoteBookControllerSafely(context);
 
 
@@ -260,6 +267,19 @@ export async function activate(context: vscode.ExtensionContext) {
 			return content;
 		}
 	});
+
+	// open folder in remote
+
+	// new command which connects to remote folder
+	vscode.commands.registerCommand(Constants.OPEN_FODLER_IN_REMOTE, async () => {
+		await lazy_load;
+		// TODO ask for folder to open
+		const filelist = await fileSystemProvider.readDirectory(vscode.Uri.parse('memfs:/'));
+		console.log(`filelist ${filelist}`);
+
+		vscode.workspace.updateWorkspaceFolders(0, 0, { uri: vscode.Uri.parse('memfs:/') });
+	});
+
 }
 
 

--- a/src/extension/native/services/client.ts
+++ b/src/extension/native/services/client.ts
@@ -3,12 +3,13 @@ import { DothttpRunOptions } from '../../web/types/misc';
 import { HttpFileTargetsDef } from '../../web/types/lang-parse';
 import { ICommandClient, RunType, DotTttpSymbol, TypeResult, ImportHarResult, ResolveResult } from '../../web/types/types';
 import * as vscode from 'vscode';
-import { ReadDirectoryOperationResult, ReadFileOperationResult, StatFileOperationResult, WriteFileOperationResult } from './fstypes';
+import { ReadDirectoryOperationResult, ReadFileOperationResult, StatFileOperationResult, SimpleOperationResult } from './fstypes';
 var mime = require('mime-types');
 
 
 
 export class ClientHandler {
+
     running: boolean = false;
     cli?: ICommandClient;
     clientLaunchArguments?: { pythonpath: string; stdargs: string[]; type: RunType; };
@@ -202,8 +203,24 @@ export class ClientHandler {
         return this.cli?.request("/fs/stat", { source: uri.fsPath });
     }
 
-    async writeFile(uri: vscode.Uri, content: Uint8Array): Promise<WriteFileOperationResult> {
+    async writeFile(uri: vscode.Uri, content: Uint8Array): Promise<SimpleOperationResult> {
         return this.cli?.request("/fs/write", { source: uri.fsPath, content: Buffer.from(content).toString('base64') });
+    }
+
+    async deleteFile(uri: vscode.Uri): Promise<SimpleOperationResult> {
+        return this.cli?.request("/fs/delete", { source: uri.fsPath });
+    }
+
+    async renameFile(oldUri: vscode.Uri, newUri: vscode.Uri): Promise<SimpleOperationResult> {
+        return this.cli?.request("/fs/rename", { old: oldUri.fsPath, new: newUri.fsPath });
+    }
+
+    async copyFile(source: vscode.Uri, destination: vscode.Uri): Promise<SimpleOperationResult> {
+        return this.cli?.request("/fs/copy", { source: source.fsPath, destination: destination.fsPath });
+    }
+
+    async createDirectory(uri: vscode.Uri): Promise<SimpleOperationResult> {
+        return this.cli?.request("/fs/create-directory", { source: uri.fsPath, });
     }
 
     close() {

--- a/src/extension/native/services/client.ts
+++ b/src/extension/native/services/client.ts
@@ -251,6 +251,24 @@ export class ClientHandler {
         }
     }
 
+    async writeFile(uri: vscode.Uri, content:  Uint8Array){
+        var ret: { "result": { "operation": string } } | { "error": boolean, "error_message": string } = await this.cli?.request("/fs/write", { source: uri.fsPath, content: Buffer.from(content).toString('base64') });
+        if ("error" in ret) {
+            switch (ret.error_message) {
+                case "FileNotFound":
+                    throw vscode.FileSystemError.FileNotFound(uri);
+                case "PermissionDenied":
+                    throw vscode.FileSystemError.NoPermissions(uri);
+                case "FileIsADirectory":
+                    throw vscode.FileSystemError.FileIsADirectory(uri);
+                case "UnknownError":
+                    throw vscode.FileSystemError.Unavailable;
+            }
+            throw new Error(ret.error_message);
+        }
+
+    }
+
 
     close() {
         this.cli?.stop();

--- a/src/extension/native/services/completion.ts
+++ b/src/extension/native/services/completion.ts
@@ -175,10 +175,8 @@ export class VariableCompletionProvider implements CompletionItemProvider {
         }
 
         const properties = _.uniq(
-            this.fileStateService?.getProperties(document.uri)
-                .filter(prop => prop.enabled)
-                .map(prop => prop.key))
-            .map(this.variableCompletionItem("From Properties"))
+            Object.keys(this.fileStateService?.getProperties(document.uri) ?? [])
+                .map(this.variableCompletionItem("From Properties")))
         return _.concat([], ...envProperties, ...properties);
     }
 

--- a/src/extension/native/services/editorIntellisense.ts
+++ b/src/extension/native/services/editorIntellisense.ts
@@ -136,7 +136,13 @@ class TypeResultMixin {
         const offset = document.offsetAt(position);
         const env = this.fileStateService.getEnv(document.uri);
         const properties: { [prop: string]: string } = {}
-        this.fileStateService.getProperties(document.uri).filter(prop => prop.enabled).map(prop => { properties[prop.key] = prop.value });
+        Object.entries(this.fileStateService.getProperties(document.uri)).forEach(([key, options]) => {
+            for (const prop of options) {
+                if (prop.enabled) {
+                    properties[key] = prop.value;
+                }
+            }
+        });
         const propertyFile = this.fileStateService.getEnvFile()?.fsPath ?? null;
         if (isNotebook) {
             const notebookDoc = vscode.window.activeNotebookEditor;
@@ -196,21 +202,21 @@ export class DothttpClickDefinitionProvider extends TypeResultMixin implements v
 
         if (result.resolved) {
             if (typeof result.resolved === 'object') {
-            hoverText = JSON.stringify(result.resolved, null, 2);
+                hoverText = JSON.stringify(result.resolved, null, 2);
             } else if (typeAtPos !== DothttpTypes.NAME) {
-            hoverText = result.resolved;
+                hoverText = result.resolved;
             }
         }
 
         if (result.property_at_pos) {
             if (result.property_at_pos.value) {
-            resolvedProperty = `## Resolved Properties \`${result.property_at_pos.name}\`
+                resolvedProperty = `## Resolved Properties \`${result.property_at_pos.name}\`
 \`\`\`jsonc
 ${JSON.stringify(result.property_at_pos.value, null, 2)}
 \`\`\`
 \n\n\n\n\n`;
             } else {
-            resolvedProperty = `## Property UnResolved \`${result.property_at_pos.name}\`
+                resolvedProperty = `## Property UnResolved \`${result.property_at_pos.name}\`
 \`Property may be not resolved in content\`
 \n\n\n\n\n`;
             }
@@ -218,7 +224,7 @@ ${JSON.stringify(result.property_at_pos.value, null, 2)}
 
         if (hoverText && resolvedProperty) {
             return new vscode.Hover(new vscode.MarkdownString(
-            `${resolvedProperty}
+                `${resolvedProperty}
 ## After Replacing Properties
 \`\`\`jsonc
 ${hoverText}
@@ -227,7 +233,7 @@ ${hoverText}
             ));
         } else if (hoverText) {
             return new vscode.Hover(new vscode.MarkdownString(
-            `## After Replacing Properties
+                `## After Replacing Properties
 \`\`\`jsonc
 ${hoverText}
 \`\`\`
@@ -235,7 +241,7 @@ ${hoverText}
             ));
         } else if (resolvedProperty) {
             return new vscode.Hover(new vscode.MarkdownString(
-            `${resolvedProperty}
+                `${resolvedProperty}
 \n\n\n\n##### Docs \n  ${DotHovers[typeAtPos].value}`
             ));
         } else {

--- a/src/extension/native/services/fsprovider.ts
+++ b/src/extension/native/services/fsprovider.ts
@@ -1,0 +1,42 @@
+import { Disposable, Event, FileChangeEvent, FileStat, FileSystemProvider, FileType, Uri } from "vscode";
+import { ClientHandler } from "./client";
+import * as vscode from 'vscode';
+
+export class SimpleFsProvider implements FileSystemProvider {
+    private clientHandler: ClientHandler;
+    constructor(clientHandler: ClientHandler) {
+        this.clientHandler = clientHandler;
+    }
+
+    private _emitter = new vscode.EventEmitter<vscode.FileChangeEvent[]>();
+
+    onDidChangeFile: Event<FileChangeEvent[]> = this._emitter.event;
+
+    watch(uri: Uri, options: { readonly recursive: boolean; readonly excludes: readonly string[]; }): Disposable {
+        throw new Error("Method not watch.");
+    }
+    stat(uri: Uri): FileStat | Thenable<FileStat> {
+        return this.clientHandler.statFile(uri);
+    }
+    readDirectory(uri: Uri): [string, FileType][] | Thenable<[string, FileType][]> {
+        return this.clientHandler.readDirectory(uri);
+    }
+    createDirectory(uri: Uri): void | Thenable<void> {
+        throw new Error("Method not create directory.");
+    }
+    readFile(uri: Uri): Uint8Array | Thenable<Uint8Array> {
+        return this.clientHandler.readFile(uri);
+    }
+    writeFile(uri: Uri, content: Uint8Array, options: { readonly create: boolean; readonly overwrite: boolean; }): void | Thenable<void> {
+        throw new Error("Method not writefile.");
+    }
+    delete(uri: Uri, options: { readonly recursive: boolean; }): void | Thenable<void> {
+        throw new Error("Method not delete.");
+    }
+    rename(oldUri: Uri, newUri: Uri, options: { readonly overwrite: boolean; }): void | Thenable<void> {
+        throw new Error("Method not rename.");
+    }
+    copy?(source: Uri, destination: Uri, options: { readonly overwrite: boolean; }): void | Thenable<void> {
+        throw new Error("Method not copy.");
+    }
+}

--- a/src/extension/native/services/fsprovider.ts
+++ b/src/extension/native/services/fsprovider.ts
@@ -28,7 +28,7 @@ export class SimpleFsProvider implements FileSystemProvider {
         return this.clientHandler.readFile(uri);
     }
     writeFile(uri: Uri, content: Uint8Array, options: { readonly create: boolean; readonly overwrite: boolean; }): void | Thenable<void> {
-        throw new Error("Method not writefile.");
+        return this.clientHandler.writeFile(uri, content);
     }
     delete(uri: Uri, options: { readonly recursive: boolean; }): void | Thenable<void> {
         throw new Error("Method not delete.");

--- a/src/extension/native/services/fsprovider.ts
+++ b/src/extension/native/services/fsprovider.ts
@@ -1,6 +1,9 @@
 import { Disposable, Event, FileChangeEvent, FileStat, FileSystemProvider, FileType, Uri } from "vscode";
 import { ClientHandler } from "./client";
 import * as vscode from 'vscode';
+import { WriteFileOperationResult } from "./fstypes";
+
+
 
 export class SimpleFsProvider implements FileSystemProvider {
     private clientHandler: ClientHandler;
@@ -15,20 +18,84 @@ export class SimpleFsProvider implements FileSystemProvider {
     watch(uri: Uri, options: { readonly recursive: boolean; readonly excludes: readonly string[]; }): Disposable {
         throw new Error("Method not watch.");
     }
-    stat(uri: Uri): FileStat | Thenable<FileStat> {
-        return this.clientHandler.statFile(uri);
+    async stat(uri: Uri): Promise<FileStat> {
+        const ret = await this.clientHandler.statFile(uri);
+        if ("error" in ret) {
+            switch (ret.error_message) {
+                case "FileNotFound":
+                    throw vscode.FileSystemError.FileNotFound(uri);
+                case "PermissionDenied":
+                    throw vscode.FileSystemError.NoPermissions(uri);
+                case "FileIsADirectory":
+                    throw vscode.FileSystemError.FileIsADirectory(uri);
+                case "UnknownError":
+                    throw vscode.FileSystemError.Unavailable;
+            }
+            throw new Error(ret.error_message);
+        } else {
+            const [st_mode, st_ino, st_dev, st_nlink, st_uid, st_gid, st_size, st_atime, st_mtime, st_ctime] = ret.result.stat;
+            return {
+                type: (st_mode & 61440) === 16384 ? vscode.FileType.Directory : vscode.FileType.File,
+                ctime: st_ctime * 1000,
+                mtime: st_mtime * 1000,
+                size: st_size,
+            };
+        }
     }
-    readDirectory(uri: Uri): [string, FileType][] | Thenable<[string, FileType][]> {
-        return this.clientHandler.readDirectory(uri);
+    async readDirectory(uri: Uri): Promise<[string, vscode.FileType][]> {
+        var ret = await this.clientHandler.readDirectory(uri);
+        return ret.result.files.map(([name, type]) => {
+            switch (type) {
+                case "file":
+                    return [name, vscode.FileType.File];
+                case "directory":
+                    return [name, vscode.FileType.Directory];
+                case "symlink":
+                    return [name, vscode.FileType.SymbolicLink];
+                default:
+                    return [name, vscode.FileType.Unknown];
+            }
+        });
     }
     createDirectory(uri: Uri): void | Thenable<void> {
         throw new Error("Method not create directory.");
     }
-    readFile(uri: Uri): Uint8Array | Thenable<Uint8Array> {
-        return this.clientHandler.readFile(uri);
+    async readFile(uri: Uri): Promise<Uint8Array> {
+        var ret = await this.clientHandler.readFile(uri);
+        if ("error" in ret) {
+            switch (ret.error_message) {
+                case "FileNotFound":
+                    throw vscode.FileSystemError.FileNotFound(uri);
+                case "PermissionDenied":
+                    throw vscode.FileSystemError.NoPermissions(uri);
+                case "FileIsADirectory":
+                    throw vscode.FileSystemError.FileIsADirectory(uri);
+                case "UnknownError":
+                    throw vscode.FileSystemError.Unavailable;
+            }
+            throw new Error(ret.error_message);
+        } else {
+            // convert base64 to buffer
+            var content = Buffer.from(ret.result.content, 'base64');
+            return new Uint8Array(content);
+        }
     }
-    writeFile(uri: Uri, content: Uint8Array, options: { readonly create: boolean; readonly overwrite: boolean; }): void | Thenable<void> {
-        return this.clientHandler.writeFile(uri, content);
+    async writeFile(uri: Uri, content: Uint8Array,
+        options: { readonly create: boolean; readonly overwrite: boolean; }): Promise<void> {
+        var ret: WriteFileOperationResult = await this.clientHandler.writeFile(uri, content);
+        if ("error" in ret) {
+            switch (ret.error_message) {
+                case "FileNotFound":
+                    throw vscode.FileSystemError.FileNotFound(uri);
+                case "PermissionDenied":
+                    throw vscode.FileSystemError.NoPermissions(uri);
+                case "FileIsADirectory":
+                    throw vscode.FileSystemError.FileIsADirectory(uri);
+                case "UnknownError":
+                    throw vscode.FileSystemError.Unavailable;
+            }
+            throw new Error(ret.error_message);
+        }
     }
     delete(uri: Uri, options: { readonly recursive: boolean; }): void | Thenable<void> {
         throw new Error("Method not delete.");

--- a/src/extension/native/services/fstypes.ts
+++ b/src/extension/native/services/fstypes.ts
@@ -1,0 +1,33 @@
+export type ReadFileOperationResult = {
+    "result": {
+        "operation": string;
+        "content": string;
+    };
+} | {
+    "error": boolean;
+    "error_message": string;
+};
+
+export type StatFileOperationResult = {
+    "result": {
+        "operation": string;
+        "stat": [number, number, number, number, number, number, number, number, number, number];
+    };
+} | {
+    "error": boolean;
+    "error_message": string;
+};
+
+
+export type ReadDirectoryOperationResult = {
+    "result": { "operation": string, "files": [[string, string]] }
+}
+
+export type WriteFileOperationResult = {
+    "result": {
+        "operation": string;
+    };
+} | {
+    "error": boolean;
+    "error_message": string;
+};

--- a/src/extension/native/services/fstypes.ts
+++ b/src/extension/native/services/fstypes.ts
@@ -1,33 +1,26 @@
-export type ReadFileOperationResult = {
-    "result": {
-        "operation": string;
-        "content": string;
-    };
-} | {
-    "error": boolean;
-    "error_message": string;
-};
-
-export type StatFileOperationResult = {
-    "result": {
-        "operation": string;
-        "stat": [number, number, number, number, number, number, number, number, number, number];
-    };
-} | {
-    "error": boolean;
-    "error_message": string;
-};
-
-
-export type ReadDirectoryOperationResult = {
-    "result": { "operation": string, "files": [[string, string]] }
+export interface FsSuccessResult<CustomResult> {
+    result: CustomResult;
 }
 
-export type WriteFileOperationResult = {
-    "result": {
-        "operation": string;
-    };
-} | {
-    "error": boolean;
-    "error_message": string;
-};
+export interface FsErrorResult {
+    error: boolean;
+    error_message: string;
+}
+
+
+export type ReadFileOperationResult = FsSuccessResult<{ operation: string, content: string }> | FsErrorResult;
+
+export type StatFileOperationResult = FsSuccessResult<
+    { operation: string, stat: [number, number, number, number, number, number, number, number, number, number] }>
+    | FsErrorResult;
+
+export type ReadDirectoryOperationResult =
+    FsSuccessResult<
+        { operation: string, files: [[string, string]] }>
+    | FsErrorResult;
+
+
+export type SimpleOperationResult =
+    FsSuccessResult<
+        { operation: string }>
+    | FsErrorResult;

--- a/src/extension/native/services/languageservers/StdoutClient.ts
+++ b/src/extension/native/services/languageservers/StdoutClient.ts
@@ -32,6 +32,18 @@ export abstract class BaseSpanClient implements ICommandClient {
                 detached: true
             },
         );
+
+        this.proc.on("exit", (code, signal) => {
+            this.running = false;
+            console.log('dotextensions cli killed, will start shortly');
+            this.channel.appendLine(`exit code: ${code} signal: ${signal}`);
+            // start after 10 seconds, 
+            // this is to avoid multiple restarts
+            setTimeout(() => {
+                this.start();
+            }, 10 * 1000);
+        }
+        );
         this.running = true;
     }
     isSupportsNative(): boolean {

--- a/src/extension/views/editor.ts
+++ b/src/extension/views/editor.ts
@@ -75,9 +75,14 @@ export default class DotHttpEditorView implements vscode.TextDocumentContentProv
     static getEnabledProperties(filename: vscode.Uri) {
         const fileservice = ApplicationServices.get().getFileStateService();
         const properties: any = {};
-        (fileservice?.getProperties(filename) ?? []).filter(prop => prop.enabled).forEach(prop => {
-            properties[prop.key] = prop.value;
-        })
+        Object.entries(fileservice?.getProperties(filename) ?? []).map(([key, options]) => {
+            for (var prop of options) {
+                if (prop.enabled) {
+                    properties[key] = prop.value;
+                    break;
+                }
+            }
+        });
         return properties;
     }
 }

--- a/src/extension/web/services/notebookkernel.ts
+++ b/src/extension/web/services/notebookkernel.ts
@@ -73,6 +73,9 @@ export class NotebookKernel {
     private async _doExecution(cell: vscode.NotebookCell, curl = false): Promise<void> {
         const execution = this._controller.createNotebookCellExecution(cell);
         execution.executionOrder = ++this._executionOrder;
+        execution.token.onCancellationRequested(() => {
+            execution.end(false, Date.now())
+        });
         const start = Date.now();
         execution.start(start);
 
@@ -86,10 +89,6 @@ export class NotebookKernel {
             .map(cell => cell.document.getText());
 
         const target: string = await this._getTarget(uri, cellNo, httpDef);
-        execution.token.onCancellationRequested(() => {
-            execution.end(false, Date.now())
-
-        });
         let isOk = false;
 
         // previous execution outputs

--- a/src/extension/web/types/properties.ts
+++ b/src/extension/web/types/properties.ts
@@ -1,12 +1,17 @@
 import * as vscode from 'vscode';
-export interface Iproperties {
-    key: string;
-    value: string;
-    enabled: boolean;
+export interface IProperty {
+    value: string,
+    description: string,
+    enabled: boolean
 }
+
+export interface IProperties {
+    [key: string]: IProperty[]
+}
+
 export interface FileInfo {
     envs: string[];
-    properties: Iproperties[];
+    properties: IProperties;
 }
 
 export interface IFileState {
@@ -15,8 +20,8 @@ export interface IFileState {
     removeEnv(file: vscode.Uri, env: string): void;
     hasEnv(file: vscode.Uri, env: string): boolean;
 
-    getProperties(file: vscode.Uri): Iproperties[];
-    addProperty(file: vscode.Uri, key: string, value: string): void;
+    getProperties(file: vscode.Uri): IProperties;
+    addProperty(file: vscode.Uri, key: string, value: string, description: string): void;
     disableProperty(file: vscode.Uri, key: string, value: string): void;
     enableProperty(file: vscode.Uri, key: string, value: string): void;
     removeProperty(file: vscode.Uri, key: string, value: string): void;

--- a/src/extension/web/utils/constants.ts
+++ b/src/extension/web/utils/constants.ts
@@ -83,6 +83,8 @@ export enum Constants {
 	updatePropCommand = 'dothttpPropView.updateproperty',
 	removePropCommand = "dothttpPropView.removeproperty",
 	disableAllPropCommand = "dothttpPropView.disableAllProperties",
+	
+	OPEN_FODLER_IN_REMOTE = "dothttp.command.openFolderInRemote",
 	// tree vars
 	propViewEnabled = "dothttpPropViewEnabled",
 


### PR DESCRIPTION
Remote FS (only when the user explicitly opts for it; it’s a limited fallback option and should only be used in critical situations where VSCode Remote fails and the request must go through the remote).


pending:
- [x] testing remote
- [x] testing property pick
- [x] incase of cli killed and started notebook exeuction, it will keep going on forever, (should handle gracefully) (stop should stop in case of cli failure)